### PR TITLE
try to fix ObjectDisposedException

### DIFF
--- a/HappyTravel.StdOutLogger/HappyTravel.StdOutLogger.csproj
+++ b/HappyTravel.StdOutLogger/HappyTravel.StdOutLogger.csproj
@@ -10,11 +10,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Logger for writing logs to the stdout in JSON format</Description>
-    <PackageReleaseNotes>OpenTelemetry headers support added</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed ObjectDisposedException when trying to access disposed request headers</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/happy-travel/stdout-logger</PackageProjectUrl>
     <RepositoryURL>https://github.com/happy-travel/stdout-logger</RepositoryURL>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.18</Version>
+    <Version>1.0.19</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HappyTravel.StdOutLogger/Internals/StdOutLogger.cs
+++ b/HappyTravel.StdOutLogger/Internals/StdOutLogger.cs
@@ -54,7 +54,7 @@ namespace HappyTravel.StdOutLogger.Internals
             }
             catch (ObjectDisposedException)
             {
-                //
+                // resume normal operation of writing log without request data 
             }
 
             var spanId = string.Empty;

--- a/HappyTravel.StdOutLogger/Internals/StdOutLogger.cs
+++ b/HappyTravel.StdOutLogger/Internals/StdOutLogger.cs
@@ -46,9 +46,16 @@ namespace HappyTravel.StdOutLogger.Internals
             
             var requestId = string.Empty;
 
-            if (_httpContextAccessor.HttpContext?.Request != null &&
-                _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(_options.RequestIdHeader, out var requestIdString))
-                requestId = requestIdString.FirstOrDefault();
+            try
+            {
+                if (_httpContextAccessor.HttpContext?.Request != null &&
+                    _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(_options.RequestIdHeader, out var requestIdString))
+                    requestId = requestIdString.FirstOrDefault();
+            }
+            catch (ObjectDisposedException)
+            {
+                //
+            }
 
             var spanId = string.Empty;
             var parentId = string.Empty; 


### PR DESCRIPTION
Sometimes logger trying to access to request headers which already has been disposed

```
System.ObjectDisposedException: IFeatureCollection has been disposed.
Object name: 'Collection'.
  Module "Microsoft.AspNetCore.Http.Features.FeatureReferences`1", in ThrowContextDisposed
  Module "Microsoft.AspNetCore.Http.DefaultHttpRequest", in get_Headers
  Module "HappyTravel.StdOutLogger.Internals.StdOutLogger", in Log
  Module "Microsoft.Extensions.Logging.Logger", in <Log>g__LoggerLog|12_0
```